### PR TITLE
fix: destroy the per-visit ApplicationInstance even when render throws

### DIFF
--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -289,8 +289,14 @@ export default async function render(
     // corrupt the next visit. This MUST run even when the render above throws
     // (settle timeout, CSS build, DOM read) — otherwise the leaked instance
     // accumulates in the long-lived worker. `instance` is undefined when
-    // app.visit() itself threw before assigning it.
-    instance?.destroy();
+    // app.visit() itself threw before assigning it. Guard the call: a destroy
+    // that throws inside this finally would skip the DOM reset below and mask
+    // the render's own error.
+    try {
+      instance?.destroy();
+    } catch {
+      /* instance teardown failed — the DOM reset below must still run */
+    }
 
     // Serialize mode leaves rehydration markers in the DOM; reset the body so
     // the next render starts from a clean slate regardless of success/failure.

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -251,6 +251,7 @@ export default async function render(
   let bodyAttrs: Record<string, string> = {};
   let cssLinks = '';
   let error: Error | undefined;
+  let instance: EmberApplicationInstance | undefined;
 
   try {
     const bootOptions: BootOptions = {
@@ -262,7 +263,7 @@ export default async function render(
       _renderMode: 'serialize',
     };
 
-    const instance = await app.visit(url, bootOptions);
+    instance = await app.visit(url, bootOptions);
 
     // Wait for the app to settle (test waiters, run loop, pending timers, etc.)
     // before reading the DOM. Falls back to a microtask drain when the SSR
@@ -279,25 +280,28 @@ export default async function render(
         bodyAttrs[attr.name] = attr.value;
       }
     }
+  } catch (e) {
+    error = e instanceof Error ? e : new Error(String(e));
+  } finally {
+    // Destroy the instance so its container is torn down cleanly. app.visit()
+    // creates a fresh ApplicationInstance per call; without destroying it the
+    // container's singletons (including location:none) remain live and can
+    // corrupt the next visit. This MUST run even when the render above throws
+    // (settle timeout, CSS build, DOM read) — otherwise the leaked instance
+    // accumulates in the long-lived worker. `instance` is undefined when
+    // app.visit() itself threw before assigning it.
+    instance?.destroy();
 
-    // Destroy the instance so its container is torn down cleanly.
-    // app.visit() creates a fresh ApplicationInstance per call; without
-    // destroying it the container's singletons (including location:none)
-    // remain live and can corrupt the next visit.
-    instance.destroy();
-
-    // Serialize mode leaves rehydration markers in the DOM, so we clear
-    // the body to ensure a clean slate for the next render.
-    document.body.innerHTML = '';
-
-    // Clear body attributes so they don't bleed into the next render.
+    // Serialize mode leaves rehydration markers in the DOM; reset the body so
+    // the next render starts from a clean slate regardless of success/failure.
     if (document.body) {
+      document.body.innerHTML = '';
+
+      // Clear body attributes so they don't bleed into the next render.
       for (const attr of Array.from(document.body.attributes)) {
         document.body.removeAttribute(attr.name);
       }
     }
-  } catch (e) {
-    error = e instanceof Error ? e : new Error(String(e));
   }
 
   const shoeboxHTML =


### PR DESCRIPTION
`instance.destroy()` and the DOM reset sat at the end of the try block, so any throw between `app.visit()` and the destroy - a settle timeout, `buildRouteCssLinks`, or the head/body reads - skipped teardown and leaked the ApplicationInstance in the long-lived render worker. Over many requests this is an unbounded memory leak.

Move `destroy()` and the DOM reset into a `finally` so they run on every path, guarding `instance` since `app.visit()` may throw before it is assigned.