### PR TITLE
fix: don't serialize Set-Cookie into the shoebox

### DIFF
--- a/vite-ember-ssr/src/fetch-middleware.ts
+++ b/vite-ember-ssr/src/fetch-middleware.ts
@@ -101,6 +101,13 @@ export function shoeboxMiddleware(
       const body = await clone.text();
       const headers: Record<string, string> = {};
       clone.headers.forEach((v, k) => {
+        // Never serialize Set-Cookie into the shoebox: it would leak the
+        // origin's (often HttpOnly) auth cookie into the rendered HTML, where
+        // any script can read it and — for a cached/shared response — hand one
+        // user's session to another. The client replays entries as
+        // JS-constructed Responses whose Set-Cookie the browser ignores, so it
+        // is inert here anyway.
+        if (k.toLowerCase() === 'set-cookie') return;
         headers[k] = v;
       });
       entries.set(request.url, {

--- a/vite-ember-ssr/tests/fetch-middleware.test.js
+++ b/vite-ember-ssr/tests/fetch-middleware.test.js
@@ -153,6 +153,28 @@ describe('shoeboxMiddleware', () => {
     expect(entry.headers['content-type']).toBe('text/plain');
   });
 
+  it('does NOT serialize Set-Cookie into the entry (auth-token leak)', async () => {
+    const entries = new Map();
+    const terminal = async () => {
+      const headers = new Headers({ 'content-type': 'application/json' });
+      headers.append('set-cookie', 'X-Auth-Token=secret; Path=/; HttpOnly');
+      return new Response('{"ok":true}', { status: 200, statusText: 'OK', headers });
+    };
+
+    await compose(
+      [shoeboxMiddleware(() => entries)],
+      terminal,
+    )('https://api.example.com/account');
+
+    const entry = entries.get('https://api.example.com/account');
+    // body + non-sensitive headers still captured for replay
+    expect(entry.body).toBe('{"ok":true}');
+    expect(entry.headers['content-type']).toBe('application/json');
+    // Set-Cookie must never reach the serialized shoebox / rendered HTML
+    expect(entry.headers['set-cookie']).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain('X-Auth-Token');
+  });
+
   it('does NOT capture when entries map is null', async () => {
     const terminal = async () => new Response('hello');
     const result = await compose(


### PR DESCRIPTION
shoeboxMiddleware copied all captured GET response headers into the serialized shoebox <script>, including Set-Cookie. When SSR forwards the viewer's cookie to an authenticated backend (forwardCookie), the backend's Set-Cookie — commonly an HttpOnly session token — was written verbatim into the rendered HTML, where any script can read it (defeating HttpOnly) and, for a cached/shared response, could hand one user's session to another.

The Set-Cookie is also inert on the client: installShoebox replays entries as JS-constructed Responses whose Set-Cookie the browser ignores. Skip it (case-insensitive) when capturing headers; body/status/content-type are untouched. Adds a regression test.