### PR TITLE
fix: bind shoebox capture to the render that started the fetch

### DIFF
--- a/vite-ember-ssr/src/fetch-middleware.ts
+++ b/vite-ember-ssr/src/fetch-middleware.ts
@@ -91,8 +91,14 @@ export function shoeboxMiddleware(
   getEntries: () => Map<string, ShoeboxEntry> | null,
 ): FetchMiddleware {
   return async (request, next) => {
-    const response = await next(request);
+    // Capture the CURRENT render's entries map before awaiting the response.
+    // A fetch left in flight by a timed-out render can resolve while a LATER
+    // render is active; calling getEntries() after the await would return
+    // that later render's map and leak this response into the wrong render's
+    // shoebox. With the reference captured up front, a late write lands in
+    // the dead render's map, which is never serialized.
     const entries = getEntries();
+    const response = await next(request);
     if (!entries) return response;
     if (request.method.toUpperCase() !== 'GET') return response;
 

--- a/vite-ember-ssr/tests/fetch-middleware.test.js
+++ b/vite-ember-ssr/tests/fetch-middleware.test.js
@@ -153,6 +153,35 @@ describe('shoeboxMiddleware', () => {
     expect(entry.headers['content-type']).toBe('text/plain');
   });
 
+  it('captures into the entries map active when the fetch STARTED, not when it resolved (cross-render leak)', async () => {
+    // Simulates an orphan fetch: started during render A (whose settled()
+    // timed out), resolving after render B has already swapped in its own
+    // entries map. The entry must land in A's dead map, never in B's.
+    const renderAEntries = new Map();
+    const renderBEntries = new Map();
+    let activeEntries = renderAEntries;
+
+    let releaseResponse;
+    const terminal = () =>
+      new Promise((resolve) => {
+        releaseResponse = () => resolve(new Response('private-of-A'));
+      });
+
+    const fn = compose([shoeboxMiddleware(() => activeEntries)], terminal);
+
+    const inFlight = fn('https://api.example.com/private');
+    // Render A dies; render B begins and installs its own map.
+    activeEntries = renderBEntries;
+    releaseResponse();
+    await inFlight;
+
+    expect(renderBEntries.size).toBe(0);
+    expect(renderAEntries.size).toBe(1);
+    expect(renderAEntries.get('https://api.example.com/private').body).toBe(
+      'private-of-A',
+    );
+  });
+
   it('does NOT capture when entries map is null', async () => {
     const terminal = async () => new Response('hello');
     const result = await compose(


### PR DESCRIPTION
shoeboxMiddleware read getEntries() after awaiting the response, so a fetch left in flight by a timed-out render resolved against whichever entries map was active at that moment — a later render's map — leaking one request's (potentially private, cookie-authenticated) response into another user's serialized shoebox.

Capture the entries map reference before awaiting next(). Late writes from orphan fetches now land in the dead render's map, which is never serialized. Adds a regression test.