### PR TITLE
Isolate render state between requests in the SSR worker

### DIFF
--- a/vite-ember-ssr/src/dev.ts
+++ b/vite-ember-ssr/src/dev.ts
@@ -73,6 +73,10 @@ const BROWSER_GLOBALS = [
 
 const SHOEBOX_SCRIPT_ID = 'vite-ember-ssr-shoebox';
 
+// Warn only once per process — the SSR entry is re-loaded on every render
+// in dev mode, so a per-render warning would flood the console.
+let warnedMissingSettled = false;
+
 // ─── Helpers ──────────────────────────────────────────────────────────
 
 function installGlobals(win: Window): Record<string, unknown> {
@@ -284,6 +288,16 @@ export function createDevEmberApp(
             if (timer) clearTimeout(timer);
           }
         } else {
+          if (settledTimeout > 0 && !warnedMissingSettled) {
+            warnedMissingSettled = true;
+            console.warn(
+              '[vite-ember-ssr] settledTimeout is set but the SSR entry does ' +
+                'not export `settled` — renders will NOT wait for the app to ' +
+                'settle and may capture incomplete HTML. Add ' +
+                "`export { settled } from '@ember/test-helpers';` to your " +
+                'SSR entry.',
+            );
+          }
           await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
 

--- a/vite-ember-ssr/src/fetch-middleware.ts
+++ b/vite-ember-ssr/src/fetch-middleware.ts
@@ -6,7 +6,7 @@
  * Koa-style onion of middlewares, each of which may inspect/modify the
  * request, await `next(req)`, and inspect/modify the response.
  *
- * Two middlewares ship with the library:
+ * Three middlewares ship with the library:
  *  - `forwardCookieMiddleware` — injects the incoming request's `Cookie`
  *    header into outbound fetches whose host appears in `allowedHosts`,
  *    so SSR can make authenticated calls on behalf of the user without
@@ -14,6 +14,9 @@
  *  - `shoeboxMiddleware` — captures GET responses into a per-render
  *    Map so they can be serialized into the HTML for the client to
  *    replay during rehydration.
+ *  - `abortSignalMiddleware` — ties outbound fetches to a per-render
+ *    AbortSignal so requests still in flight when a render finishes are
+ *    aborted instead of lingering into later renders.
  *
  * Worker mode installs the pipeline once at startup and swaps per-render
  * state via getters; dev mode rebuilds the pipeline per request with
@@ -76,6 +79,37 @@ export function forwardCookieMiddleware(
     const merged = new Headers(request.headers);
     merged.set('cookie', cookie.value);
     return next(new Request(request, { headers: merged }));
+  };
+}
+
+/**
+ * Middleware that ties outbound fetches to a per-render AbortSignal, so
+ * requests still in flight when the render finishes (typically after a
+ * `settled()` timeout) are aborted instead of lingering into later
+ * renders on the same worker.
+ *
+ * @param getSignal Function returning the active per-render signal, or
+ *   `null` when no render-scoped abort is configured.
+ */
+export function abortSignalMiddleware(
+  getSignal: () => AbortSignal | null,
+): FetchMiddleware {
+  return (request, next) => {
+    const signal = getSignal();
+    if (!signal) return next(request);
+
+    // Preserve any signal app code attached to its own request.
+    const combined = request.signal
+      ? AbortSignal.any([request.signal, signal])
+      : signal;
+    const result = next(new Request(request, { signal: combined }));
+
+    // A render-scoped abort fires after the app that issued the fetch has
+    // been torn down, so its rejection may have nothing left awaiting it.
+    // Pre-attach a no-op handler to keep such late rejections from crashing
+    // the worker as unhandled; the caller still receives the rejection.
+    result.catch(() => {});
+    return result;
   };
 }
 

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -29,6 +29,7 @@ import type {
   ForwardedCookie,
 } from './server.js';
 import {
+  abortSignalMiddleware,
   compose,
   forwardCookieMiddleware,
   shoeboxMiddleware,
@@ -151,11 +152,13 @@ const SHOEBOX_SCRIPT_ID = 'vite-ember-ssr-shoebox';
 const realFetch = globalThis.fetch;
 let activeShoebox: Map<string, ShoeboxEntry> | null = null;
 let activeCookie: ForwardedCookie | null = null;
+let activeAbort: AbortController | null = null;
 
 const fetchWithMiddleware = compose(
   [
     forwardCookieMiddleware(() => activeCookie),
     shoeboxMiddleware(() => activeShoebox),
+    abortSignalMiddleware(() => activeAbort?.signal ?? null),
   ],
   (request) => realFetch(request),
 );
@@ -248,6 +251,7 @@ export default async function render(
   // single shared pipeline can serve every render without re-installation.
   activeShoebox = shoebox ? new Map() : null;
   activeCookie = forwardCookie;
+  activeAbort = new AbortController();
 
   // Snapshot the pre-render <head> state so the finally below can restore
   // it. ember-page-title and similar addons write into <head> during the
@@ -334,6 +338,13 @@ export default async function render(
     } catch {
       /* storage unavailable in this happy-dom configuration */
     }
+
+    // Abort any fetches this render left in flight (e.g. after a settled()
+    // timeout) so they stop consuming the connection instead of lingering
+    // into later renders. Their shoebox entries — if a response still
+    // arrives — go to this render's already-dead map (see shoeboxMiddleware).
+    activeAbort?.abort();
+    activeAbort = null;
   }
 
   const shoeboxHTML =

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -210,8 +210,19 @@ function buildRouteCssLinks(
   return links.join('');
 }
 
+let warnedMissingSettled = false;
+
 async function awaitSettled(timeoutMs: number): Promise<void> {
   if (!appSettled) {
+    if (timeoutMs > 0 && !warnedMissingSettled) {
+      warnedMissingSettled = true;
+      console.warn(
+        '[vite-ember-ssr] settledTimeout is set but the SSR bundle does not ' +
+          'export `settled` — renders will NOT wait for the app to settle ' +
+          'and may capture incomplete HTML. Add ' +
+          "`export { settled } from '@ember/test-helpers';` to your SSR entry.",
+      );
+    }
     // Fallback: drain Backburner's autorun microtask before reading the DOM.
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
     return;

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -6,9 +6,12 @@
  * every render. Renders are serialised by tinypool (concurrentTasksPerWorker:1),
  * so there is no concurrency concern within a single worker.
  *
- * app.visit() fully owns document.head/body between calls, so DOM state does
- * not bleed across renders. A fresh ApplicationInstance is created per visit
- * and destroyed after the DOM is read, keeping container singletons clean.
+ * A fresh ApplicationInstance is created per visit and destroyed after the
+ * DOM is read, keeping container singletons clean. Because the Window is
+ * long-lived, every render resets the mutable per-request window state in a
+ * finally block: document.body (content + attributes), document.head/title,
+ * and local/session storage. Without this, one request's DOM or storage
+ * writes would bleed into the next request served by this worker.
  *
  * The shoebox fetch interceptor is installed once at startup. Each render
  * assigns a fresh entries Map before visiting, so entries never bleed between
@@ -246,6 +249,13 @@ export default async function render(
   activeShoebox = shoebox ? new Map() : null;
   activeCookie = forwardCookie;
 
+  // Snapshot the pre-render <head> state so the finally below can restore
+  // it. ember-page-title and similar addons write into <head> during the
+  // render; without a reset, one request's document title (which may contain
+  // private data) bleeds into every later render served by this worker.
+  const preRenderTitle = document.title;
+  const preRenderHead = document.head?.innerHTML ?? '';
+
   let head = '';
   let body = '';
   let bodyAttrs: Record<string, string> = {};
@@ -307,6 +317,22 @@ export default async function render(
       for (const attr of Array.from(document.body.attributes)) {
         document.body.removeAttribute(attr.name);
       }
+    }
+
+    // Restore <head> (and the title) to its pre-render state. The rendered
+    // head HTML was already captured above, so anything the render added —
+    // <title> via ember-page-title, meta tags, etc. — must not survive into
+    // the next request's document.
+    if (document.head) document.head.innerHTML = preRenderHead;
+    if (document.title !== preRenderTitle) document.title = preRenderTitle;
+
+    // Clear web storage so values written during the render (user
+    // preferences, cached tokens) don't bleed into the next request.
+    try {
+      win.localStorage.clear();
+      win.sessionStorage.clear();
+    } catch {
+      /* storage unavailable in this happy-dom configuration */
     }
   }
 

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -289,8 +289,14 @@ export default async function render(
     // corrupt the next visit. This MUST run even when the render above throws
     // (settle timeout, CSS build, DOM read) — otherwise the leaked instance
     // accumulates in the long-lived worker. `instance` is undefined when
-    // app.visit() itself threw before assigning it.
-    instance?.destroy();
+    // app.visit() itself threw before assigning it. Guard the call: a destroy
+    // that throws inside this finally would skip the DOM reset below and mask
+    // the render's own error.
+    try {
+      instance?.destroy();
+    } catch {
+      /* instance teardown failed — the DOM reset below must still run */
+    }
 
     // Serialize mode leaves rehydration markers in the DOM; reset the body so
     // the next render starts from a clean slate regardless of success/failure.

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -251,6 +251,7 @@ export default async function render(
   let bodyAttrs: Record<string, string> = {};
   let cssLinks = '';
   let error: Error | undefined;
+  let instance: EmberApplicationInstance | undefined;
 
   try {
     const bootOptions: BootOptions = {
@@ -262,7 +263,7 @@ export default async function render(
       _renderMode: 'serialize',
     };
 
-    const instance = await app.visit(url, bootOptions);
+    instance = await app.visit(url, bootOptions);
 
     // Wait for the app to settle (test waiters, run loop, pending timers, etc.)
     // before reading the DOM. Falls back to a microtask drain when the SSR
@@ -279,25 +280,28 @@ export default async function render(
         bodyAttrs[attr.name] = attr.value;
       }
     }
+  } catch (e) {
+    error = e instanceof Error ? e : new Error(String(e));
+  } finally {
+    // Destroy the instance so its container is torn down cleanly. app.visit()
+    // creates a fresh ApplicationInstance per call; without destroying it the
+    // container's singletons (including location:none) remain live and can
+    // corrupt the next visit. This MUST run even when the render above throws
+    // (settle timeout, CSS build, DOM read) — otherwise the leaked instance
+    // accumulates in the long-lived worker. `instance` is undefined when
+    // app.visit() itself threw before assigning it.
+    instance?.destroy();
 
-    // Destroy the instance so its container is torn down cleanly.
-    // app.visit() creates a fresh ApplicationInstance per call; without
-    // destroying it the container's singletons (including location:none)
-    // remain live and can corrupt the next visit.
-    instance.destroy();
-
-    // Serialize mode leaves rehydration markers in the DOM, so we clear
-    // the body to ensure a clean slate for the next render.
-    document.body.innerHTML = '';
-
-    // Clear body attributes so they don't bleed into the next render.
+    // Serialize mode leaves rehydration markers in the DOM; reset the body so
+    // the next render starts from a clean slate regardless of success/failure.
     if (document.body) {
+      document.body.innerHTML = '';
+
+      // Clear body attributes so they don't bleed into the next render.
       for (const attr of Array.from(document.body.attributes)) {
         document.body.removeAttribute(attr.name);
       }
     }
-  } catch (e) {
-    error = e instanceof Error ? e : new Error(String(e));
   }
 
   const shoeboxHTML =

--- a/vite-ember-ssr/tests/fetch-middleware.test.js
+++ b/vite-ember-ssr/tests/fetch-middleware.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
+  abortSignalMiddleware,
   compose,
   forwardCookieMiddleware,
   shoeboxMiddleware,
@@ -173,6 +174,79 @@ describe('shoeboxMiddleware', () => {
     );
 
     expect(entries.size).toBe(0);
+  });
+});
+
+// ─── abortSignalMiddleware ───────────────────────────────────────────
+
+describe('abortSignalMiddleware', () => {
+  it('passes through unchanged when no signal is configured', async () => {
+    let observed;
+    const terminal = async (req) => {
+      observed = req;
+      return new Response('ok');
+    };
+
+    const original = new Request('https://api.example.com/x');
+    await compose([abortSignalMiddleware(() => null)], terminal)(original);
+
+    expect(observed.signal.aborted).toBe(false);
+  });
+
+  it('attaches the render signal so aborting cancels the outbound request', async () => {
+    const controller = new AbortController();
+    let observed;
+    const terminal = async (req) => {
+      observed = req;
+      return new Response('ok');
+    };
+
+    await compose(
+      [abortSignalMiddleware(() => controller.signal)],
+      terminal,
+    )('https://api.example.com/x');
+
+    expect(observed.signal.aborted).toBe(false);
+    controller.abort();
+    expect(observed.signal.aborted).toBe(true);
+  });
+
+  it("also honours the app's own signal on the request", async () => {
+    const renderController = new AbortController();
+    const appController = new AbortController();
+    let observed;
+    const terminal = async (req) => {
+      observed = req;
+      return new Response('ok');
+    };
+
+    await compose(
+      [abortSignalMiddleware(() => renderController.signal)],
+      terminal,
+    )('https://api.example.com/x', { signal: appController.signal });
+
+    expect(observed.signal.aborted).toBe(false);
+    appController.abort();
+    expect(observed.signal.aborted).toBe(true);
+  });
+
+  it('rejects the in-flight fetch when the render signal aborts', async () => {
+    const controller = new AbortController();
+    const terminal = (req) =>
+      new Promise((_resolve, reject) => {
+        req.signal.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError')),
+        );
+      });
+
+    const inFlight = compose(
+      [abortSignalMiddleware(() => controller.signal)],
+      terminal,
+    )('https://api.example.com/orphan');
+
+    controller.abort();
+
+    await expect(inFlight).rejects.toThrow('aborted');
   });
 });
 


### PR DESCRIPTION
The SSR worker reuses one long-lived happy-dom Window and one worker-module scope across every render it serves. Several pieces of per-render state were never reset or scoped, so  one request's data could leak into a later request served by the same worker. This PR isolates that state. Three related fixes:

- Reset head, title, and web storage between renders. The worker only reset document.body between renders. Anything a render wrote to document.head (ember-page-title output, meta  tags), document.title, localStorage, or sessionStorage survived into every later render on that worker - one user's private page title could appear in another user's <title>,  and stored preferences bled across requests. Snapshots the pre-render head/title and restores them in the render finally, and clears local/session storage there too.
- Abort orphan fetches when a render finishes. Adds abortSignalMiddleware, tying every outbound fetch to a per-render AbortSignal (combined with any signal the app attached  itself). The worker creates an AbortController per render and aborts it in the render finally, so fetches left in flight by a timed-out render are cancelled instead of lingering  into later renders. Late abort rejections may have nothing awaiting them once the app instance is destroyed, so the middleware pre-attaches a no-op rejection handler - the caller  still sees the rejection, but the worker can't crash on an unhandled one.
- Warn loudly when the bundle exports no settled. The renderer silently fell back to a single setTimeout(0) drain when the bundle exports no settled, so a configured  settledTimeout looked like it was working while renders captured potentially incomplete HTML. Emits a console.warn once (per worker in production, per process in dev) explaining  the fallback and how to fix it. Skipped when settledTimeout is 0, which reads as intentionally disabled.

Depends on #13 - please merge that first

The head/title/storage reset and the fetch-abort both run in the render finally block introduced by #13("destroy the per-visit ApplicationInstance even when  render throws"). On main today the instance teardown still lives inside the try, so there is no finally for this cleanup to attach to.

Because this branch is built on top of that one, until #13 merges this PR's diff will also show its two commits (destroy the per-visit ApplicationInstance… and  guard instance.destroy()…).