### PR TITLE
feat: warn loudly when the SSR bundle exports no settled function

### DIFF
--- a/vite-ember-ssr/src/dev.ts
+++ b/vite-ember-ssr/src/dev.ts
@@ -73,6 +73,10 @@ const BROWSER_GLOBALS = [
 
 const SHOEBOX_SCRIPT_ID = 'vite-ember-ssr-shoebox';
 
+// Warn only once per process — the SSR entry is re-loaded on every render
+// in dev mode, so a per-render warning would flood the console.
+let warnedMissingSettled = false;
+
 // ─── Helpers ──────────────────────────────────────────────────────────
 
 function installGlobals(win: Window): Record<string, unknown> {
@@ -284,6 +288,16 @@ export function createDevEmberApp(
             if (timer) clearTimeout(timer);
           }
         } else {
+          if (settledTimeout > 0 && !warnedMissingSettled) {
+            warnedMissingSettled = true;
+            console.warn(
+              '[vite-ember-ssr] settledTimeout is set but the SSR entry does ' +
+                'not export `settled` — renders will NOT wait for the app to ' +
+                'settle and may capture incomplete HTML. Add ' +
+                "`export { settled } from '@ember/test-helpers';` to your " +
+                'SSR entry.',
+            );
+          }
           await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
 

--- a/vite-ember-ssr/src/worker.ts
+++ b/vite-ember-ssr/src/worker.ts
@@ -204,8 +204,19 @@ function buildRouteCssLinks(
   return links.join('');
 }
 
+let warnedMissingSettled = false;
+
 async function awaitSettled(timeoutMs: number): Promise<void> {
   if (!appSettled) {
+    if (timeoutMs > 0 && !warnedMissingSettled) {
+      warnedMissingSettled = true;
+      console.warn(
+        '[vite-ember-ssr] settledTimeout is set but the SSR bundle does not ' +
+          'export `settled` — renders will NOT wait for the app to settle ' +
+          'and may capture incomplete HTML. Add ' +
+          "`export { settled } from '@ember/test-helpers';` to your SSR entry.",
+      );
+    }
     // Fallback: drain Backburner's autorun microtask before reading the DOM.
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
     return;


### PR DESCRIPTION
The renderer silently fell back to a single setTimeout(0) drain when the bundle exports no `settled`, so a configured settledTimeout looked like it was working while renders captured potentially incomplete HTML. Emit a console.warn once (per worker in production, per process in dev) explaining the fallback and how to fix it. Skipped when settledTimeout is 0, which reads as intentionally disabled.