### PR TITLE
fix: make the shoebox fetch interceptor transparent to native-fetch detection

### DIFF
--- a/vite-ember-ssr/src/client.ts
+++ b/vite-ember-ssr/src/client.ts
@@ -135,6 +135,16 @@ export function installShoebox(): boolean {
     return Promise.resolve(response);
   };
 
+  // Advertise the original fetch's source so the wrapper is transparent to
+  // native-fetch detection. Some libraries sniff `fetch.toString()` to decide
+  // whether a mock environment is active and change behavior on it — e.g.
+  // warp-drive's dev builds assume mutable (Mirage-style) response headers and
+  // crash on real responses ("Headers are immutable") while the shoebox
+  // interceptor is installed. The wrapper delegates to the original fetch for
+  // everything it doesn't serve, so reporting its source is accurate enough.
+  const originalSource = _originalFetch.toString();
+  globalThis.fetch.toString = () => originalSource;
+
   return true;
 }
 

--- a/vite-ember-ssr/tests/browser.browser.js
+++ b/vite-ember-ssr/tests/browser.browser.js
@@ -141,6 +141,53 @@ test.describe('Shoebox prevents duplicate fetches on first client load', () => {
     );
   });
 
+  test('shoebox interceptor is transparent to native-fetch detection', async ({
+    page,
+  }) => {
+    // Libraries sniff fetch.toString() to detect mock environments (e.g.
+    // warp-drive's dev builds, which then treat response headers as mutable
+    // and crash on real immutable ones). The interceptor installs and
+    // uninstalls itself quickly, so trap every assignment to globalThis.fetch
+    // and assert each assigned function still reports the native source.
+    await page.addInitScript(() => {
+      const assigned = [];
+      let current = globalThis.fetch;
+      window.__nativeFetchSource = current.toString();
+      window.__assignedFetches = assigned;
+      Object.defineProperty(globalThis, 'fetch', {
+        configurable: true,
+        get: () => current,
+        set: (value) => {
+          assigned.push(value);
+          current = value;
+        },
+      });
+    });
+
+    await page.goto('/pokemon-fetch');
+    await page.waitForFunction(
+      () => document.body.classList.contains('ember-application'),
+      { timeout: 15_000 },
+    );
+    // Shoebox fully consumed → interceptor was installed and restored
+    await page.waitForFunction(
+      () => !document.getElementById('vite-ember-ssr-shoebox'),
+      { timeout: 5_000 },
+    );
+
+    const { nativeSource, sources } = await page.evaluate(() => ({
+      nativeSource: window.__nativeFetchSource,
+      sources: window.__assignedFetches.map((fn) => fn.toString()),
+    }));
+
+    // installShoebox() assigned the interceptor, cleanupShoebox() restored
+    // the original — both must be indistinguishable from native fetch.
+    expect(sources.length).toBeGreaterThanOrEqual(2);
+    for (const source of sources) {
+      expect(source).toBe(nativeSource);
+    }
+  });
+
   test('no PokeAPI requests on initial pokemon-fetch load (data served from shoebox)', async ({
     page,
   }) => {


### PR DESCRIPTION
Some libraries change behavior based on whether globalThis.fetch looks native. warp-drive's dev builds sniff fetch.toString() to detect Mirage/Pretender-style mock environments; while the shoebox interceptor is installed, that heuristic misfires and warp-drive mutates the headers of real (immutable) fetch Responses directly, throwing

    TypeError: Failed to execute 'set' on 'Headers': Headers are immutable

on any successful GET whose response lacks a readable Date header. The failure is timing-dependent (a race between shoebox consumption, which restores the original fetch, and in-flight responses), which made it show up as a flaky hydration-time error.

Since shoeboxFetch delegates to the original fetch for everything it does not serve from the shoebox, advertise the original's source via a toString override. Regression test traps assignments to globalThis.fetch and asserts every assigned function reports the native source.

This only seems to be a dev issue so far, so please feel free to close if you don't think fixing it is important enough.